### PR TITLE
Fix DNS resolution

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,6 +299,7 @@ func main() {
 		logger.Infof("successfully connected to %v. Response: %v", u.NetworkService(), resp)
 	}
 
+
 	// Wait for cancel event to terminate
 	<-signalCtx.Done()
 }

--- a/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout/handler.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout/handler.go
@@ -103,6 +103,12 @@ func (h *fanoutHandler) waitResponse(ctx context.Context, respCh <-chan *dns.Msg
 				continue
 			}
 			if resp.Rcode == dns.RcodeSuccess {
+				if len(resp.Answer) == 0 {
+                                        if respCount == 0 {
+                                                return nil
+                                        }
+                                        continue
+                                }
 				return resp
 			}
 			if respCount == 0 {


### PR DESCRIPTION
Fixed resolution of names when a custom DNS server address is provided in the NSE response. When a custom dns endpoint with a specific search domain is provided, there would be two DNS servers:
kube-dns to resolve cluster.local names and the custom dns to resolve custom domain names.

The NSM dnsutils code sends DNS queries to both the servers simultaneously and returns prematurely if one of the servers sends a response with zero answers, leading to an empty response to the querier.

Signed-off-by: Bharath Horatti <bharath@aveshasystems.com>