### PR TITLE
fix(): Fix dns caching

### DIFF
--- a/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/cache/handler.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/cache/handler.go
@@ -42,6 +42,7 @@ func (h *dnsCacheHandler) ServeDNS(ctx context.Context, rw dns.ResponseWriter, m
 		v := val.Copy()
 		if validateMsg(v) {
 			v.Id = m.Id
+			log.FromContext(ctx).WithField("dnsCacheHandler", "ServeDNS").Debugf("returning from cache: %v, ans: %v", v, v.Answer)
 			if err := rw.WriteMsg(v); err != nil {
 				log.FromContext(ctx).WithField("dnsCacheHandler", "ServeDNS").Warnf("got an error during write the message: %v", err.Error())
 				dns.HandleFailed(rw, v)

--- a/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/cache/response_writer_wrapper.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/cache/response_writer_wrapper.go
@@ -26,7 +26,7 @@ type responseWriterWrapper struct {
 }
 
 func (r *responseWriterWrapper) WriteMsg(m *dns.Msg) error {
-	if m != nil && m.Rcode == dns.RcodeSuccess {
+	if m != nil && m.Rcode == dns.RcodeSuccess && len(m.Answer) > 0 {
 		r.cache.Store(m.Question[0], m)
 	}
 	return r.ResponseWriter.WriteMsg(m)

--- a/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout/handler.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout/handler.go
@@ -74,19 +74,10 @@ func (h *fanoutHandler) ServeDNS(ctx context.Context, rw dns.ResponseWriter, msg
 	var resp = h.waitResponse(ctx, responseCh)
 
 	if resp == nil {
-		m := new(dns.Msg)
 		// TODO: The waitResponse() func needs to be improved to return the correct error code if none of the
 		// queried nameservers return an answer. We need a way to aggregate the error codes and choose what error
 		// to write in the dns response message if different nameservers returned different error codes.
-		// Return NXDOMAIN error code by default if resp is empty. Returning SERVFAIL is problematic because it
-		// means the server does not want to return an answer due to an internal error or similar errors. It
-		// indicates that the server might have the answer but does not want to return it. Many apps seem to treat this
-		// as a blanket dns server failure, leading to unexpected side effects.
-		m.SetRcode(msg, dns.RcodeNameError)
-		err := rw.WriteMsg(m)
-		if err != nil {
-			log.FromContext(ctx).WithField("fanoutHandler", "ServeDNS").Warnf("Error writing NameError: %v", err.Error())
-		}
+		dns.HandleFailed(rw, msg)
 		return
 	}
 

--- a/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/searches/handler.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/searches/handler.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	timeout = 5 * time.Second
+	timeout = 10 * time.Second
 )
 
 type searchDomainsHandler struct {
@@ -73,6 +73,7 @@ func (h *searchDomainsHandler) ServeDNS(ctx context.Context, rw dns.ResponseWrit
 	}
 
 	if respIdx >= 0 {
+		log.FromContext(ctx).WithField("searchDomainsHandler", "ServeDNS").Debugf("Returning response: %v", r.Responses[respIdx])
 		r.Responses[respIdx].Question = m.Question
 		if err := rw.WriteMsg(r.Responses[respIdx]); err != nil {
 			log.FromContext(ctx).WithField("searchDomainsHandler", "ServeDNS").Warnf("got an error during write the message: %v", err.Error())


### PR DESCRIPTION
The cache chain in the dns proxy server caches responses with no data in the answer section but the ttl update and validation functions expect the answer section to be present in the cached entries. This causes infinite caching of entries without any answer section and dns queries returned with empty responses without the queries being forwarded to the upstream dns servers.

Added a conditional to check for the availability of the Answer section before storing the response in the cache.

Signed-off-by: Bharath Horatti <bharath@aveshasystems.com>