### PR TITLE
fix(): Added primary dns server in fanout handler

### DIFF
--- a/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout/handler.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout/handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/clienturlctx"
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/searches"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
@@ -37,7 +38,9 @@ type fanoutHandler struct {
 
 func (h *fanoutHandler) ServeDNS(ctx context.Context, rw dns.ResponseWriter, msg *dns.Msg) {
 	var connectTO = clienturlctx.ClientURLs(ctx)
+	var searchDomains = searches.SearchDomains(ctx)
 	var responseCh = make(chan *dns.Msg, len(connectTO))
+	var primaryDnsServerUrl *url.URL = nil
 
 	deadline, _ := ctx.Deadline()
 	timeout := time.Until(deadline)
@@ -46,6 +49,49 @@ func (h *fanoutHandler) ServeDNS(ctx context.Context, rw dns.ResponseWriter, msg
 		log.FromContext(ctx).WithField("fanoutHandler", "ServeDNS").Error("no urls to fanout")
 		dns.HandleFailed(rw, msg)
 		return
+	}
+
+	for iter, searchDomain := range searchDomains {
+		if searchDomain == "slice.local" {
+			if iter < len(connectTO) {
+				primaryDnsServerUrl = &connectTO[iter]
+			}
+			break
+		}
+	}
+
+	log.FromContext(ctx).WithField("fanoutHandler", "ServeDNS").Debugf("Primary dns: %v", primaryDnsServerUrl)
+
+	if primaryDnsServerUrl != nil {
+		var client = dns.Client{
+			Net:     primaryDnsServerUrl.Scheme,
+			Timeout: timeout,
+		}
+
+		address := primaryDnsServerUrl.Host
+		if primaryDnsServerUrl.Port() == "" {
+			address += fmt.Sprintf(":%d", h.dnsPort)
+		}
+
+		var resp, _, err = client.Exchange(msg, address)
+		if err != nil {
+			log.FromContext(ctx).WithField("fanoutHandler", "ServeDNS").Warnf("got an error during exchanging with primary %v: %v", address, err.Error())
+		} else {
+			if resp != nil {
+				log.FromContext(ctx).WithField("fanoutHandler", "ServeDNS").Debugf("recvd resp from primary: %v", resp)
+				if resp.Rcode == dns.RcodeSuccess {
+					if len(resp.Answer) > 0 {
+						if err := rw.WriteMsg(resp); err != nil {
+							log.FromContext(ctx).WithField("fanoutHandler", "ServeDNS").Warnf("got an error during write the message: %v", err.Error())
+							dns.HandleFailed(rw, msg)
+							return
+						}
+						next.Handler(ctx).ServeDNS(ctx, rw, resp)
+						return
+					}
+				}
+			}
+		}
 	}
 
 	for i := 0; i < len(connectTO); i++ {


### PR DESCRIPTION
This is a temp fix. If slice.local is present in the search domains, use the corresponding dns server as the primary server. DNS requests are first sent to the primary, and the request is passed on to other servers only if the primary cannot resolve the query.